### PR TITLE
Introduce pluggable attachment system

### DIFF
--- a/CRM/Mailbatch/Form/Task/ContactEmail.php
+++ b/CRM/Mailbatch/Form/Task/ContactEmail.php
@@ -101,7 +101,7 @@ class CRM_Mailbatch_Form_Task_ContactEmail extends CRM_Contact_Form_Task
             E::ts('Send if attachment not found?')
         );
 
-        $this->addAttachmentElements();
+        $this->addAttachmentElements(['entity_type' => 'contact']);
 
         $activity_types = $this->getActivityTypes();
         $this->add(
@@ -197,6 +197,7 @@ class CRM_Mailbatch_Form_Task_ContactEmail extends CRM_Contact_Form_Task
         $contact_count = count($this->_contactIds) - $no_email_count;
 
         // store default values
+        // TODO: Use contactSettings().
         Civi::settings()->set('batchmail_template_id', $values['template_id']);
         Civi::settings()->set('batchmail_sender_email', $values['sender_email']);
         Civi::settings()->set('batchmail_batch_size', $values['batch_size']);

--- a/CRM/Mailbatch/Form/Task/ContactEmail.php
+++ b/CRM/Mailbatch/Form/Task/ContactEmail.php
@@ -15,12 +15,15 @@
 +--------------------------------------------------------*/
 
 use CRM_Mailbatch_ExtensionUtil as E;
+use Civi\Mailbatch\Form\Task\AttachmentsTrait;
 
 /**
  * Send E-Mail to contacts task
  */
 class CRM_Mailbatch_Form_Task_ContactEmail extends CRM_Contact_Form_Task
 {
+    use AttachmentsTrait;
+
     /**
      * Compile task form
      */
@@ -97,6 +100,8 @@ class CRM_Mailbatch_Form_Task_ContactEmail extends CRM_Contact_Form_Task
             'send_wo_attachment',
             E::ts('Send if attachment not found?')
         );
+
+        $this->addAttachmentElements();
 
         $this->add(
             'text',

--- a/CRM/Mailbatch/Form/Task/ContactEmail.php
+++ b/CRM/Mailbatch/Form/Task/ContactEmail.php
@@ -103,22 +103,6 @@ class CRM_Mailbatch_Form_Task_ContactEmail extends CRM_Contact_Form_Task
 
         $this->addAttachmentElements();
 
-        $this->add(
-            'text',
-            'attachment1_path',
-            E::ts('Attachment Path/URL'),
-            ['class' => 'huge'],
-            false
-        );
-
-        $this->add(
-            'text',
-            'attachment1_name',
-            E::ts('Attachment Name'),
-            ['class' => 'huge'],
-            false
-        );
-
         $activity_types = $this->getActivityTypes();
         $this->add(
             'select',

--- a/CRM/Mailbatch/Form/Task/ContactEmail.php
+++ b/CRM/Mailbatch/Form/Task/ContactEmail.php
@@ -191,8 +191,7 @@ class CRM_Mailbatch_Form_Task_ContactEmail extends CRM_Contact_Form_Task
             'sender_reply_to'          => Civi::settings()->get('batchmail_sender_reply_to'),
             'send_wo_attachment'       => Civi::settings()->get('batchmail_send_wo_attachment'),
             //'enable_smarty'            => Civi::settings()->get('batchmail_enable_smarty'),
-            'attachment1_path'         => Civi::settings()->get('batchmail_attachment1_path'),
-            'attachment1_name'         => Civi::settings()->get('batchmail_attachment1_name'),
+            // TODO: Set default values for attachments?
             'sent_activity_type_id'    => Civi::settings()->get('batchmail_sent_activity_type_id'),
             'sent_activity_grouped'    => Civi::settings()->get('batchmail_sent_activity_grouped'),
             'sent_activity_subject'    => Civi::settings()->get('batchmail_sent_activity_subject'),
@@ -222,8 +221,6 @@ class CRM_Mailbatch_Form_Task_ContactEmail extends CRM_Contact_Form_Task
         Civi::settings()->set('batchmail_sender_reply_to', $values['sender_reply_to']);
         Civi::settings()->set('batchmail_send_wo_attachment', CRM_Utils_Array::value('send_wo_attachment', $values, 0));
         //Civi::settings()->set('batchmail_enable_smarty',            CRM_Utils_Array::value('enable_smarty', $values, 0));
-        Civi::settings()->set('batchmail_attachment1_path', $values['attachment1_path']);
-        Civi::settings()->set('batchmail_attachment1_name', $values['attachment1_name']);
         Civi::settings()->set('batchmail_sent_activity_type_id', $values['sent_activity_type_id']);
         Civi::settings()->set('batchmail_sent_activity_subject', $values['sent_activity_subject']);
         Civi::settings()->set('batchmail_failed_activity_type_id', $values['failed_activity_type_id']);
@@ -233,6 +230,8 @@ class CRM_Mailbatch_Form_Task_ContactEmail extends CRM_Contact_Form_Task
         if (isset($values['failed_activity_subject2'])) {
             Civi::settings()->set('batchmail_failed_activity_subject2', $values['failed_activity_subject2']);
         }
+
+        $values['attachments'] = $this->processAttachments();
 
         // generate no-email activities for contacts with no emails if required
         if ($no_email_count > 0

--- a/CRM/Mailbatch/SendContributionMailJob.php
+++ b/CRM/Mailbatch/SendContributionMailJob.php
@@ -91,6 +91,7 @@ class CRM_Mailbatch_SendContributionMailJob extends CRM_Mailbatch_SendMailJob
 
                     // add attachments
                     $attachments = [];
+                    // TODO: refactor to use pluggable attachment system.
                     $attachment_file = $this->findAttachmentFile($contact_id, 1, $contribution_id);
                     if ($attachment_file) {
                         $file_name = empty($this->config['attachment1_name']) ? basename($attachment_file) : $this->config['attachment1_name'];

--- a/CRM/Mailbatch/SendMailJob.php
+++ b/CRM/Mailbatch/SendMailJob.php
@@ -64,6 +64,11 @@ class CRM_Mailbatch_SendMailJob
             // trigger sendMessageTo for each one of them
             $mail_successfully_sent = [];
             $mail_sending_failed = [];
+            $attachment_types = \Civi\Mailbatch\Form\Task\AttachmentsTrait::attachmentTypes();
+            // TODO: Pre-cache attachments for all contacts in the batch, wrapped in try...catch.
+//            foreach ($this->config['attachments'] as $attachment_id => $attachment_values) {
+//                $attachment_type['controller']::preCacheAttachments(['contacts' => $contacts['values']], $attachment_values);
+//            }
             foreach ($contacts['values'] as $contact) {
                 try {
                     // send email
@@ -83,7 +88,6 @@ class CRM_Mailbatch_SendMailJob
                     ];
 
                     // Add attachments.
-                    $attachment_types = \Civi\Mailbatch\Form\Task\AttachmentsTrait::attachmentTypes();
                     foreach ($this->config['attachments'] as $attachment_id => $attachment_values) {
                         $attachment_type = $attachment_types[$attachment_values['type']];
                         if (

--- a/Civi/Mailbatch/AttachmentType/AttachmentTypeInterface.php
+++ b/Civi/Mailbatch/AttachmentType/AttachmentTypeInterface.php
@@ -20,9 +20,44 @@ use CRM_Mailbatch_ExtensionUtil as E;
 
 interface AttachmentTypeInterface
 {
+    /**
+     * TODO: Document what needs to be returned.
+     *
+     * @param $form
+     * @param $attachment_id
+     *
+     * @return mixed
+     */
     public static function buildAttachmentForm(&$form, $attachment_id);
 
     public static function processAttachmentForm(&$form, $attachment_id);
 
     public static function buildAttachment($context, $attachment_values);
+
+    /**
+     * TODO: Optional pre-caching of attachments for a batch of entites to be
+     *       used in self::buildAttachment() instead of slow generation
+     *       one-by-one.
+     *
+     * @param $context
+     * @param $attachment_values
+     *
+     * @return bool
+     *   Whether the caching was successful.
+     */
+//    public static function preCacheAttachments($context, $attachment_values);
+
+    /**
+     * TODO: Inform attachment providers that things are done:
+     *       - a batch of contacts
+     *       - the entire task
+     *       so that generated attachments can be cleaned up.
+     *
+     * Optional
+     *
+     * @param $context
+     *
+     * @return mixed
+     */
+//    public static function cleanUpAttachments($context);
 }

--- a/Civi/Mailbatch/AttachmentType/AttachmentTypeInterface.php
+++ b/Civi/Mailbatch/AttachmentType/AttachmentTypeInterface.php
@@ -1,0 +1,28 @@
+<?php
+/*-------------------------------------------------------+
+| SYSTOPIA MailBatch Extension                           |
+| Copyright (C) 2021 SYSTOPIA                            |
+| Author: J. Schuppe (schuppe@systopia.de)               |
+| http://www.systopia.de/                                |
++--------------------------------------------------------+
+| This program is released as free software under the    |
+| Affero GPL license. You can redistribute it and/or     |
+| modify it under the terms of this license which you    |
+| can read by viewing the included agpl.txt or online    |
+| at www.gnu.org/licenses/agpl.html. Removal of this     |
+| copyright header is strictly prohibited without        |
+| written permission from the original author(s).        |
++--------------------------------------------------------*/
+
+namespace Civi\Mailbatch\AttachmentType;
+
+use CRM_Mailbatch_ExtensionUtil as E;
+
+interface AttachmentTypeInterface
+{
+    public static function buildAttachmentForm(&$form, $attachment_id);
+
+    public static function processAttachmentForm(&$form, $attachment_id);
+
+    public static function buildAttachment($context, $attachment_values);
+}

--- a/Civi/Mailbatch/AttachmentType/Generic.php
+++ b/Civi/Mailbatch/AttachmentType/Generic.php
@@ -16,6 +16,7 @@
 
 namespace Civi\Mailbatch\AttachmentType;
 
+use Civi\Mailbatch\Form\Task\AttachmentsTrait;
 use CRM_Mailbatch_ExtensionUtil as E;
 
 class Generic implements AttachmentTypeInterface
@@ -67,7 +68,7 @@ class Generic implements AttachmentTypeInterface
             $file_name = empty($attachment_values['name']) ? basename($attachment_file) : $attachment_values['name'];
             $attachment = [
                 'fullPath' => $attachment_file,
-                'mime_type' => self::getMimeType($attachment_file),
+                'mime_type' => AttachmentsTrait::getMimeType($attachment_file),
                 'cleanName' => $file_name,
             ];
         }
@@ -97,22 +98,6 @@ class Generic implements AttachmentTypeInterface
             }
         }
         return null;
-    }
-
-    /**
-     * get the mime type of the given file
-     *
-     * @param string $path
-     *
-     * @return string mime type
-     */
-    protected static function getMimeType($path)
-    {
-        static $known_files = [];
-        if (!isset($known_files[$path])) {
-            $known_files[$path] = mime_content_type($path);
-        }
-        return $known_files[$path];
     }
 
 }

--- a/Civi/Mailbatch/AttachmentType/Generic.php
+++ b/Civi/Mailbatch/AttachmentType/Generic.php
@@ -1,0 +1,118 @@
+<?php
+/*-------------------------------------------------------+
+| SYSTOPIA MailBatch Extension                           |
+| Copyright (C) 2021 SYSTOPIA                            |
+| Author: J. Schuppe (schuppe@systopia.de)               |
+| http://www.systopia.de/                                |
++--------------------------------------------------------+
+| This program is released as free software under the    |
+| Affero GPL license. You can redistribute it and/or     |
+| modify it under the terms of this license which you    |
+| can read by viewing the included agpl.txt or online    |
+| at www.gnu.org/licenses/agpl.html. Removal of this     |
+| copyright header is strictly prohibited without        |
+| written permission from the original author(s).        |
++--------------------------------------------------------*/
+
+namespace Civi\Mailbatch\AttachmentType;
+
+use CRM_Mailbatch_ExtensionUtil as E;
+
+class Generic implements AttachmentTypeInterface
+{
+
+    /**
+     * @param \CRM_Core_Form_Task $form
+     *
+     * @param int $attachment_id
+     *
+     * @return array
+     */
+    public static function buildAttachmentForm(&$form, $attachment_id)
+    {
+        $form->add(
+            'text',
+            'attachments--' . $attachment_id . '--path',
+            E::ts('Attachment Path/URL'),
+            ['class' => 'huge'],
+            false
+        );
+
+        $form->add(
+            'text',
+            'attachments--' . $attachment_id . '--name',
+            E::ts('Attachment Name'),
+            ['class' => 'huge'],
+            false
+        );
+        return [
+            'attachments--' . $attachment_id . '--path' => 'attachment-generic-path',
+            'attachments--' . $attachment_id . '--name' => 'attachment-generic-name',
+        ];
+    }
+
+    public static function processAttachmentForm(&$form, $attachment_id)
+    {
+        $values = $form->exportValues();
+        return [
+            'path' => $values['attachments--' . $attachment_id . '--path'],
+            'name' => $values['attachments--' . $attachment_id . '--name'],
+        ];
+    }
+
+    public static function buildAttachment($context, $attachment_values)
+    {
+        $attachment_file = self::findAttachmentFile($context['contact']['id'], 1, $attachment_values['path']);
+        if ($attachment_file) {
+            $file_name = empty($attachment_values['name']) ? basename($attachment_file) : $attachment_values['name'];
+            $attachment = [
+                'fullPath' => $attachment_file,
+                'mime_type' => self::getMimeType($attachment_file),
+                'cleanName' => $file_name,
+            ];
+        }
+        return $attachment ?? null;
+    }
+
+    /**
+     * Try to find the attachment #{$index} based on the file path
+     *   and the contact
+     *
+     * @param integer $contact_id
+     *   contact ID
+     *
+     * @param integer $index
+     *   index
+     *
+     * @return string|null
+     *   full file path or null
+     */
+    protected static function findAttachmentFile($contact_id, $index = 1, $path)
+    {
+        if (!empty($path)) {
+            // replace {contact_id} token
+            $path = preg_replace('/[{]contact_id[}]/', $contact_id, $path);
+            if (is_readable($path) && !is_dir($path)) {
+                return $path;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * get the mime type of the given file
+     *
+     * @param string $path
+     *
+     * @return string mime type
+     */
+    protected static function getMimeType($path)
+    {
+        static $known_files = [];
+        if (!isset($known_files[$path])) {
+            $known_files[$path] = mime_content_type($path);
+        }
+        return $known_files[$path];
+    }
+
+}

--- a/Civi/Mailbatch/Form/Task/AttachmentsTrait.php
+++ b/Civi/Mailbatch/Form/Task/AttachmentsTrait.php
@@ -1,0 +1,101 @@
+<?php
+/*-------------------------------------------------------+
+| SYSTOPIA MailBatch Extension                           |
+| Copyright (C) 2021 SYSTOPIA                            |
+| Author: J. Schuppe (schuppe@systopia.de)               |
+| http://www.systopia.de/                                |
++--------------------------------------------------------+
+| This program is released as free software under the    |
+| Affero GPL license. You can redistribute it and/or     |
+| modify it under the terms of this license which you    |
+| can read by viewing the included agpl.txt or online    |
+| at www.gnu.org/licenses/agpl.html. Removal of this     |
+| copyright header is strictly prohibited without        |
+| written permission from the original author(s).        |
++--------------------------------------------------------*/
+
+namespace Civi\Mailbatch\Form\Task;
+
+use CRM_Mailbatch_ExtensionUtil as E;
+
+/**
+ * For use in classes extending CRM_Core_Form_Task.
+ */
+trait AttachmentsTrait
+{
+    /**
+     * @var array $attachments
+     */
+    protected $attachments = [];
+
+    /**
+     * @return array
+     */
+    public function getAttachments()
+    {
+        return $this->attachments;
+    }
+
+    public function addAttachment($id, $settings = NULL) {
+        $this->attachments[$id] = $settings;
+    }
+
+    /**
+     * @var string
+     */
+    protected $_ajax_action;
+
+    public function addAttachmentElements()
+    {
+        $attachment_count = 0;
+        $attachment_elements = [];
+
+        // Get all current attachment fields when adding via Ajax.
+        if (
+            ($this->_ajax_action = \CRM_Utils_Request::retrieve('ajax_action', 'String', $this))
+            && $this->_ajax_action == 'add_attachment'
+        ) {
+            while (true) {
+                $attachment_count++;
+                // TODO: Retrieve type for each attachment and retrieve settings depending on type from separate fields.
+                $current_attachment = \CRM_Utils_Request::retrieve(
+                    'attachments--' . $attachment_count,
+                    'Json',
+                    $this
+                );
+                $this->addAttachment($attachment_count, $current_attachment);
+                if (is_null($current_attachment)) {
+                    break;
+                }
+            }
+        }
+
+        $attachment_count = 0;
+        foreach ($this->getAttachments() as $attachment_settings) {
+            $attachment_count++;
+            // TODO: Add type element.
+
+            // TODO: Add settings elements depending on type.
+            $this->add(
+                'textarea',
+                'attachments--' . $attachment_count,
+                E::ts('Attachment settings'),
+                [
+                    'rows' => 3,
+                    'cols' => 80,
+                ]
+            );
+            $attachment_elements[$attachment_count] = 'attachments--' . $attachment_count;
+        }
+        $this->assign('attachment_elements', $attachment_elements);
+
+        $this->add(
+            'button',
+            'attachments_more',
+            E::ts('Add attachment')
+        );
+        \CRM_Core_Resources::singleton()->addScriptFile(E::LONG_NAME, 'js/attachments.js', 1, 'html-header');
+        $this->addClass('crm-mailbatch-attachments-form');
+    }
+
+}

--- a/Civi/Mailbatch/Form/Task/AttachmentsTrait.php
+++ b/Civi/Mailbatch/Form/Task/AttachmentsTrait.php
@@ -134,9 +134,10 @@ trait AttachmentsTrait
         $event = GenericHookEvent::create(['attachment_types' => &$attachment_types]);
         \Civi::dispatcher()->dispatch('civi.mailbatch.attachmentTypes', $event);
 
-        // TODO: array_diff $context['entity_types'] with the attachment types' contexts for deciding whether they match.
         return !empty($context['entity_type']) ? array_filter($attachment_types, function($attachment_type) use ($context) {
-            return in_array($context['entity_type'], $attachment_type['context']['entity_types']);
+            return
+                empty($attachment_type['context']['entity_types'])
+                || in_array($context['entity_type'], $attachment_type['context']['entity_types']);
         }) : $attachment_types;
     }
 

--- a/Civi/Mailbatch/Form/Task/AttachmentsTrait.php
+++ b/Civi/Mailbatch/Form/Task/AttachmentsTrait.php
@@ -120,4 +120,20 @@ trait AttachmentsTrait
         return $attachment_types;
     }
 
+    /**
+     * get the mime type of the given file
+     *
+     * @param string $path
+     *
+     * @return string mime type
+     */
+    public static function getMimeType($path)
+    {
+        static $known_files = [];
+        if (!isset($known_files[$path])) {
+            $known_files[$path] = mime_content_type($path);
+        }
+        return $known_files[$path];
+    }
+
 }

--- a/js/attachments.js
+++ b/js/attachments.js
@@ -64,6 +64,7 @@
           qfKey: $form.find('[name="qfKey"]').val(),
           ajax_context: 'attachments',
           ajax_action: 'add_attachment',
+          ajax_attachment_type: $attachmentsWrapper.find('[name="attachments_more_type"]').val(),
           snippet: 6
         };
         var $currentAttachments = $attachmentsWrapper.find('[name^="attachments--"]');

--- a/js/attachments.js
+++ b/js/attachments.js
@@ -1,0 +1,88 @@
+/*-------------------------------------------------------+
+| SYSTOPIA MailBatch Extension                           |
+| Copyright (C) 2021 SYSTOPIA                            |
+| Author: J. Schuppe (schuppe@systopia.de)               |
+| http://www.systopia.de/                                |
++--------------------------------------------------------+
+| This program is released as free software under the    |
+| Affero GPL license. You can redistribute it and/or     |
+| modify it under the terms of this license which you    |
+| can read by viewing the included agpl.txt or online    |
+| at www.gnu.org/licenses/agpl.html. Removal of this     |
+| copyright header is strictly prohibited without        |
+| written permission from the original author(s).        |
++--------------------------------------------------------*/
+(function($) {
+
+  $.urlParam = function (name) {
+    var results = new RegExp('[\?&]' + name + '=([^&#]*)')
+      .exec(window.location.search);
+
+    return (results !== null) ? results[1] || 0 : false;
+  };
+
+  $(document).ready(function() {
+    var $form = $('form.crm-mailbatch-attachments-form');
+    var $attachmentsWrapper = $form.find('#crm-mailbatch-attachments-wrapper');
+    $attachmentsWrapper
+      .css('position', 'relative')
+      .append(
+        $('<div>')
+          .hide()
+          .addClass('loading-overlay')
+          .css({
+            backgroundColor: 'rgba(255, 255, 255, 0.5)',
+            position: 'absolute',
+            top: 0,
+            right: 0,
+            bottom: 0,
+            left: 0
+          })
+          .append(
+            $('<div>')
+              .addClass('crm-loading-element')
+              .css({
+                position: 'absolute',
+                left: '50%',
+                top: '50%',
+                marginLeft: '-15px',
+                marginTop: '-15px'
+              })
+          )
+      );
+    $('#attachments_more')
+      .on('click', function() {
+        var urlSearchparams = new URLSearchParams(window.location.search);
+        urlSearchparams.append('ajax_action', 'add_attachment');
+        var postValues = {
+          qfKey: $form.find('[name="qfKey"]').val(),
+          ajax_action: 'add_attachment',
+          snippet: 6
+        };
+        var $currentAttachments = $form.find('[name^="attachments--"]');
+        $currentAttachments.each(function() {
+          postValues[$(this).attr('name')] = $(this).val();
+        });
+
+        $attachmentsWrapper.find('.loading-overlay').show();
+
+        // Retrieve the form with another attachment field.
+        $.post(
+          CRM.url(
+            location.pathname.substr(1),
+            location.search.substr(1)
+          ),
+          postValues,
+          function(data) {
+            $attachmentsWrapper
+              .find('.crm-mailbatch-attachments-table tbody')
+              .append($(data.content)
+                .find('#crm-mailbatch-attachments-wrapper table.crm-mailbatch-attachments-table tr.crm-mailbatch-attachment').last()
+              );
+            $attachmentsWrapper.find('.loading-overlay').hide();
+          }
+        );
+      });
+  });
+
+})(CRM.$ || cj);

--- a/templates/CRM/Mailbatch/Form/Task/ContactEmail.hlp
+++ b/templates/CRM/Mailbatch/Form/Task/ContactEmail.hlp
@@ -14,7 +14,7 @@
 
 {crmScope extensionKey='de.systopia.mailbatch'}
 
-{htxt id='id-attachment-name'}
+{htxt id='id-attachment-generic-name'}
   {ts}This the the name the recipient will receive the attachment under.{/ts}
   {ts}Leave empty to go with the original name.{/ts}
 {/htxt}
@@ -24,7 +24,7 @@
   {ts}SMARTY can negatively interact with inline html styling or font declarations, so if you don't have straightforward HTML content, you might run into issues using SMARTY as well.{/ts}
 {/htxt}
 
-{htxt id='id-attachment-path'}
+{htxt id='id-attachment-generic-path'}
   {ts}This needs to specify an absolute file path that is accessible from CiviCRM.{/ts}
   {ts}In Order to send different attachments per contact, you can use the token <code>{literal}{{/literal}contact_id{literal}}{/literal}</code> in the filename.{/ts}
 {/htxt}

--- a/templates/CRM/Mailbatch/Form/Task/ContactEmail.tpl
+++ b/templates/CRM/Mailbatch/Form/Task/ContactEmail.tpl
@@ -13,152 +13,182 @@
 +-------------------------------------------------------*}
 
 {crmScope extensionKey='de.systopia.mailbatch'}
-{if $no_email_count}
-  <div id="help">{ts 1=$no_email_count}<b>Warning:</b> %1 contact(s) have no viable email address, an email will not be sent to them{/ts}</div>
-{/if}
+  <div class="crm-block crm-form-block">
+      {if $no_email_count}
+        <div id="help">{ts 1=$no_email_count}
+            <b>Warning:</b>
+            %1 contact(s) have no viable email address, an email will not be sent to them{/ts}
+        </div>
+      {/if}
 
-  <h3>{ts}Mailing Properties{/ts}</h3><br/>
+    <div class="crm-accordion-wrapper">
+      <div class="crm-accordion-header">{ts}Mailing Properties{/ts}</div>
+      <div class="crm-accordion-body">
 
-  <div class="crm-section">
-    <div class="label">{$form.sender_email.label}</div>
-    <div class="content">{$form.sender_email.html}</div>
-    <div class="clear"></div>
-  </div>
+        <div class="crm-section">
+          <div class="label">{$form.sender_email.label}</div>
+          <div class="content">{$form.sender_email.html}</div>
+          <div class="clear"></div>
+        </div>
 
-  <div class="crm-section">
-    <div class="label">{$form.sender_cc.label}</div>
-    <div class="content">{$form.sender_cc.html}</div>
-    <div class="clear"></div>
-  </div>
+        <div class="crm-section">
+          <div class="label">{$form.sender_cc.label}</div>
+          <div class="content">{$form.sender_cc.html}</div>
+          <div class="clear"></div>
+        </div>
 
-  <div class="crm-section">
-    <div class="label">{$form.sender_bcc.label}</div>
-    <div class="content">{$form.sender_bcc.html}</div>
-    <div class="clear"></div>
-  </div>
+        <div class="crm-section">
+          <div class="label">{$form.sender_bcc.label}</div>
+          <div class="content">{$form.sender_bcc.html}</div>
+          <div class="clear"></div>
+        </div>
 
-  <div class="crm-section">
-    <div class="label">{$form.sender_reply_to.label}</div>
-    <div class="content">{$form.sender_reply_to.html}</div>
-    <div class="clear"></div>
-  </div>
+        <div class="crm-section">
+          <div class="label">{$form.sender_reply_to.label}</div>
+          <div class="content">{$form.sender_reply_to.html}</div>
+          <div class="clear"></div>
+        </div>
 
-  <div class="crm-section">
-    <div class="label">{$form.batch_size.label}</div>
-    <div class="content">{$form.batch_size.html}</div>
-    <div class="clear"></div>
-  </div>
+        <div class="crm-section">
+          <div class="label">{$form.batch_size.label}</div>
+          <div class="content">{$form.batch_size.html}</div>
+          <div class="clear"></div>
+        </div>
 
+      </div>
+    </div>
 
-  <h3>{ts}Content{/ts}</h3><br/>
+    <div class="crm-accordion-wrapper">
+      <div class="crm-accordion-header">{ts}Content{/ts}</div>
+      <div class="crm-accordion-body">
 
-  <div class="crm-section">
-    <div class="label">{$form.template_id.label}</div>
-    <div class="content">{$form.template_id.html}</div>
-    <div class="clear"></div>
-  </div>
+        <div class="crm-section">
+          <div class="label">{$form.template_id.label}</div>
+          <div class="content">{$form.template_id.html}</div>
+          <div class="clear"></div>
+        </div>
 
-{*  <div class="crm-section">*}
-{*    <div class="label">{$form.enable_smarty.label}&nbsp;{help id="id-smarty" title=$form.enable_smarty.label}</div>*}
-{*    <div class="content">{$form.enable_smarty.html}</div>*}
-{*    <div class="clear"></div>*}
-{*  </div>*}
+          {*  <div class="crm-section">*}
+          {*    <div class="label">{$form.enable_smarty.label}&nbsp;{help id="id-smarty" title=$form.enable_smarty.label}</div>*}
+          {*    <div class="content">{$form.enable_smarty.html}</div>*}
+          {*    <div class="clear"></div>*}
+          {*  </div>*}
 
-  <div class="crm-section">
-    <div class="label">{$form.send_wo_attachment.label}&nbsp;{help id="id-no-attachment" title=$form.send_wo_attachment.label}</div>
-    <div class="content">{$form.send_wo_attachment.html}</div>
-    <div class="clear"></div>
-  </div>
+        <div class="crm-section">
+          <div class="label">{$form.send_wo_attachment.label}
+            &nbsp;{help id="id-no-attachment" title=$form.send_wo_attachment.label}</div>
+          <div class="content">{$form.send_wo_attachment.html}</div>
+          <div class="clear"></div>
+        </div>
 
-  <div class="crm-section">
-    <div class="label">{$form.attachment1_path.label}&nbsp;{help id="id-attachment-path" title=$form.attachment1_path.label}</div>
-    <div class="content">{$form.attachment1_path.html}</div>
-    <div class="clear"></div>
-  </div>
+        <div class="crm-section">
+          <div class="label">{$form.attachment1_path.label}
+            &nbsp;{help id="id-attachment-path" title=$form.attachment1_path.label}</div>
+          <div class="content">{$form.attachment1_path.html}</div>
+          <div class="clear"></div>
+        </div>
 
-  <div class="crm-section">
-    <div class="label">{$form.attachment1_name.label}&nbsp;{help id="id-attachment-name" title=$form.attachment1_name.label}</div>
-    <div class="content">{$form.attachment1_name.html}</div>
-    <div class="clear"></div>
-  </div>
+        <div class="crm-section">
+          <div class="label">{$form.attachment1_name.label}
+            &nbsp;{help id="id-attachment-name" title=$form.attachment1_name.label}</div>
+          <div class="content">{$form.attachment1_name.html}</div>
+          <div class="clear"></div>
+        </div>
 
+      </div>
+    </div>
 
-  <h3>{ts}Activities{/ts}</h3><br/>
+    <div class="crm-accordion-wrapper">
+      <div class="crm-accordion-header">{ts}Attachments{/ts}</div>
+      <div class="crm-accordion-body">
+          {include file="Civi/Mailbatch/Form/Task/AttachmentsTrait.tpl"}
+      </div>
+    </div>
 
-  <div class="crm-section">
-    <div class="label">{$form.sent_activity_type_id.label}</div>
-    <div class="content">{$form.sent_activity_type_id.html}</div>
-    <div class="clear"></div>
-  </div>
+    <div class="crm-accordion-wrapper">
+      <div class="crm-accordion-header">{ts}Activities{/ts}</div>
+      <div class="crm-accordion-body">
 
-  <div class="crm-section mailbatch-sent-section">
-    <div class="label">{$form.sent_activity_subject.label}</div>
-    <div class="content">{$form.sent_activity_subject.html}</div>
-    <div class="clear"></div>
-  </div>
+        <div class="crm-section">
+          <div class="label">{$form.sent_activity_type_id.label}</div>
+          <div class="content">{$form.sent_activity_type_id.html}</div>
+          <div class="clear"></div>
+        </div>
 
-  <div class="crm-section">
-    <div class="label">{$form.failed_activity_type_id.label}</div>
-    <div class="content">{$form.failed_activity_type_id.html}</div>
-    <div class="clear"></div>
-  </div>
+        <div class="crm-section mailbatch-sent-section">
+          <div class="label">{$form.sent_activity_subject.label}</div>
+          <div class="content">{$form.sent_activity_subject.html}</div>
+          <div class="clear"></div>
+        </div>
 
-  <div class="crm-section mailbatch-failed-section">
-    <div class="label">{$form.failed_activity_subject.label}</div>
-    <div class="content">{$form.failed_activity_subject.html}</div>
-    <div class="clear"></div>
-  </div>
+        <div class="crm-section">
+          <div class="label">{$form.failed_activity_type_id.label}</div>
+          <div class="content">{$form.failed_activity_type_id.html}</div>
+          <div class="clear"></div>
+        </div>
 
-  {if $form.failed_activity_subject2}
-  <div class="crm-section mailbatch-failed-section">
-    <div class="label">{$form.failed_activity_subject2.label}&nbsp;{help id="id-failed-no-email" title=$form.attachment1_path.label}</div>
-    <div class="content">{$form.failed_activity_subject2.html}</div>
-    <div class="clear"></div>
-  </div>
-  {/if}
+        <div class="crm-section mailbatch-failed-section">
+          <div class="label">{$form.failed_activity_subject.label}</div>
+          <div class="content">{$form.failed_activity_subject.html}</div>
+          <div class="clear"></div>
+        </div>
 
-  <div class="crm-section mailbatch-failed-section">
-    <div class="label">{$form.failed_activity_assignee.label}</div>
-    <div class="content">{$form.failed_activity_assignee.html}</div>
-    <div class="clear"></div>
-  </div>
+          {if $form.failed_activity_subject2}
+            <div class="crm-section mailbatch-failed-section">
+              <div class="label">{$form.failed_activity_subject2.label}
+                &nbsp;{help id="id-failed-no-email" title=$form.attachment1_path.label}</div>
+              <div class="content">{$form.failed_activity_subject2.html}</div>
+              <div class="clear"></div>
+            </div>
+          {/if}
 
-  <div class="crm-section">
-    <div class="label">{$form.activity_grouped.label}</div>
-    <div class="content">{$form.activity_grouped.html}</div>
-    <div class="clear"></div>
-  </div>
+        <div class="crm-section mailbatch-failed-section">
+          <div class="label">{$form.failed_activity_assignee.label}</div>
+          <div class="content">{$form.failed_activity_assignee.html}</div>
+          <div class="clear"></div>
+        </div>
 
-  <br>
-  <div class="crm-submit-buttons">
-      {include file="CRM/common/formButtons.tpl" location="bottom"}
+        <div class="crm-section">
+          <div class="label">{$form.activity_grouped.label}</div>
+          <div class="content">{$form.activity_grouped.html}</div>
+          <div class="clear"></div>
+        </div>
+
+      </div>
+    </div>
+
+    <div class="crm-submit-buttons">
+        {include file="CRM/common/formButtons.tpl" location="bottom"}
+    </div>
   </div>
 {/crmScope}
 
 {literal}
-<script>
-  cj(document).ready(function() {
-    // add logic to sent_activity
-    cj("[name=sent_activity_type_id]").change(function() {
-      let active = cj("[name=sent_activity_type_id]").val();
-      if (active) {
-        cj("div.mailbatch-sent-section").show();
-      } else {
-        cj("div.mailbatch-sent-section").hide();
-      }
-    });
-    cj("[name=sent_activity_type_id]").change();
+  <script>
+    cj(document).ready(function () {
+      // add logic to sent_activity
+      cj("[name=sent_activity_type_id]").change(function () {
+        let active = cj("[name=sent_activity_type_id]").val();
+        if (active) {
+          cj("div.mailbatch-sent-section").show();
+        }
+        else {
+          cj("div.mailbatch-sent-section").hide();
+        }
+      });
+      cj("[name=sent_activity_type_id]").change();
 
-    // add logic to failed_activity
-    cj("[name=failed_activity_type_id]").change(function() {
-      let active = cj("[name=failed_activity_type_id]").val();
-      if (active) {
-        cj("div.mailbatch-failed-section").show();
-      } else {
-        cj("div.mailbatch-failed-section").hide();
-      }
+      // add logic to failed_activity
+      cj("[name=failed_activity_type_id]").change(function () {
+        let active = cj("[name=failed_activity_type_id]").val();
+        if (active) {
+          cj("div.mailbatch-failed-section").show();
+        }
+        else {
+          cj("div.mailbatch-failed-section").hide();
+        }
+      });
+      cj("[name=failed_activity_type_id]").change();
     });
-    cj("[name=failed_activity_type_id]").change();
-  });
-</script>
+  </script>
 {/literal}

--- a/templates/CRM/Mailbatch/Form/Task/ContactEmail.tpl
+++ b/templates/CRM/Mailbatch/Form/Task/ContactEmail.tpl
@@ -74,6 +74,13 @@
           {*    <div class="clear"></div>*}
           {*  </div>*}
 
+      </div>
+    </div>
+
+    <div class="crm-accordion-wrapper">
+      <div class="crm-accordion-header">{ts}Attachments{/ts}</div>
+      <div class="crm-accordion-body">
+
         <div class="crm-section">
           <div class="label">{$form.send_wo_attachment.label}
             &nbsp;{help id="id-no-attachment" title=$form.send_wo_attachment.label}</div>
@@ -81,27 +88,8 @@
           <div class="clear"></div>
         </div>
 
-        <div class="crm-section">
-          <div class="label">{$form.attachment1_path.label}
-            &nbsp;{help id="id-attachment-path" title=$form.attachment1_path.label}</div>
-          <div class="content">{$form.attachment1_path.html}</div>
-          <div class="clear"></div>
-        </div>
+        {include file="Civi/Mailbatch/Form/Task/AttachmentsTrait.tpl"}
 
-        <div class="crm-section">
-          <div class="label">{$form.attachment1_name.label}
-            &nbsp;{help id="id-attachment-name" title=$form.attachment1_name.label}</div>
-          <div class="content">{$form.attachment1_name.html}</div>
-          <div class="clear"></div>
-        </div>
-
-      </div>
-    </div>
-
-    <div class="crm-accordion-wrapper">
-      <div class="crm-accordion-header">{ts}Attachments{/ts}</div>
-      <div class="crm-accordion-body">
-          {include file="Civi/Mailbatch/Form/Task/AttachmentsTrait.tpl"}
       </div>
     </div>
 

--- a/templates/Civi/Mailbatch/Form/Task/AttachmentsTrait.tpl
+++ b/templates/Civi/Mailbatch/Form/Task/AttachmentsTrait.tpl
@@ -20,7 +20,7 @@
           {foreach from=$attachments item="attachment_elements" key="attachment_id"}
             <tr class="crm-mailbatch-attachment">
 
-              <td>
+              <td style="width: 100%;">
                   {foreach from=$attachment_elements key="attachment_element" item="attachment_element_type"}
                     <div class="crm-section">
                       <div class="label">

--- a/templates/Civi/Mailbatch/Form/Task/AttachmentsTrait.tpl
+++ b/templates/Civi/Mailbatch/Form/Task/AttachmentsTrait.tpl
@@ -17,15 +17,17 @@
 
       <table class="crm-mailbatch-attachments-table row-highlight">
           <tbody>
-          {foreach from=$attachment_elements item=attachment_element}
+          {foreach from=$attachments item="attachment_elements"}
             <tr class="crm-mailbatch-attachment">
-              <td>
-                <div class="crm-section">
-                  <div class="label">{$form.$attachment_element.label}</div>
-                  <div class="content">{$form.$attachment_element.html}</div>
-                  <div class="clear"></div>
-                </div>
-              </td>
+              {foreach from=$attachment_elements item="attachment_element"}
+                <td>
+                  <div class="crm-section">
+                    <div class="label">{$form.$attachment_element.label}</div>
+                    <div class="content">{$form.$attachment_element.html}</div>
+                    <div class="clear"></div>
+                  </div>
+                </td>
+              {/foreach}
             </tr>
           {/foreach}
           </tbody>

--- a/templates/Civi/Mailbatch/Form/Task/AttachmentsTrait.tpl
+++ b/templates/Civi/Mailbatch/Form/Task/AttachmentsTrait.tpl
@@ -1,0 +1,36 @@
+{*-------------------------------------------------------+
+| SYSTOPIA Event Messages                                |
+| Copyright (C) 2021 SYSTOPIA                            |
+| Author: J. Schuppe (schuppe@systopia.de)               |
++--------------------------------------------------------+
+| This program is released as free software under the    |
+| Affero GPL license. You can redistribute it and/or     |
+| modify it under the terms of this license which you    |
+| can read by viewing the included agpl.txt or online    |
+| at www.gnu.org/licenses/agpl.html. Removal of this     |
+| copyright header is strictly prohibited without        |
+| written permission from the original author(s).        |
++-------------------------------------------------------*}
+
+{crmScope extensionKey='de.systopia.mailbatch'}
+  <div id="crm-mailbatch-attachments-wrapper">
+
+      <table class="crm-mailbatch-attachments-table row-highlight">
+          <tbody>
+          {foreach from=$attachment_elements item=attachment_element}
+            <tr class="crm-mailbatch-attachment">
+              <td>
+                <div class="crm-section">
+                  <div class="label">{$form.$attachment_element.label}</div>
+                  <div class="content">{$form.$attachment_element.html}</div>
+                  <div class="clear"></div>
+                </div>
+              </td>
+            </tr>
+          {/foreach}
+          </tbody>
+      </table>
+
+      {$form.attachments_more.html}
+  </div>
+{/crmScope}

--- a/templates/Civi/Mailbatch/Form/Task/AttachmentsTrait.tpl
+++ b/templates/Civi/Mailbatch/Form/Task/AttachmentsTrait.tpl
@@ -17,22 +17,34 @@
 
       <table class="crm-mailbatch-attachments-table row-highlight">
           <tbody>
-          {foreach from=$attachments item="attachment_elements"}
+          {foreach from=$attachments item="attachment_elements" key="attachment_id"}
             <tr class="crm-mailbatch-attachment">
-              {foreach from=$attachment_elements item="attachment_element"}
-                <td>
-                  <div class="crm-section">
-                    <div class="label">{$form.$attachment_element.label}</div>
-                    <div class="content">{$form.$attachment_element.html}</div>
-                    <div class="clear"></div>
-                  </div>
-                </td>
-              {/foreach}
+
+              <td>
+                  {foreach from=$attachment_elements key="attachment_element" item="attachment_element_type"}
+                    <div class="crm-section">
+                      <div class="label">
+                          {$form.$attachment_element.label}
+                          {capture assign="help_id"}id-{$attachment_element_type}{/capture}
+                          {help id=$help_id title=$form.$attachment_element.label}
+                      </div>
+                      <div class="content">{$form.$attachment_element.html}</div>
+                      <div class="clear"></div>
+                    </div>
+                  {/foreach}
+              </td>
+
+              <td>
+                  {capture assign="attachment_remove_button_name"}attachments--{$attachment_id}_remove{/capture}
+                  {$form.$attachment_remove_button_name.html}
+              </td>
+
             </tr>
           {/foreach}
           </tbody>
       </table>
 
+      {$form.attachments_more_type.html}
       {$form.attachments_more.html}
   </div>
 {/crmScope}


### PR DESCRIPTION
This adds a pluggable attachment system to the search result task forms, allowing the user to add an arbitrary number of attachments from different sources. Those are called attachment types and they are being registered through a Symfony event.

Each attachment types is to be implemented in a separate class implementing an interface. Thus, methods for

- defining form fields
- processing form fields
- building the attachment

must be implemented by each attachment type.

The legacy attachment type, which attaches files already existing in a configurable path and optionally replaces contact/contribution IDs in the file name, is being registered as such an attachment type.

Resolves #3.